### PR TITLE
Update AgriFood datamodels to include verb-based relationships

### DIFF
--- a/definitions/Agri-Crop.md
+++ b/definitions/Agri-Crop.md
@@ -13,9 +13,9 @@ This entity contains a harmonised description of a generic crop. This entity is 
 | name | Property | The name of this crop. | Mandatory |
 | alternateName | Property | An alternative name for this crop. | Optional |
 | description | Property | A description of this crop. | Recommended |
-| agriSoil | Relationship | Reference to the recommended types of soil suitable for growing this crop. | Optional |
-| agriFertiliser | Relationship | Reference to the recommended types of fertiliser suitable for growing this crop. | Optional |
-| agriPest | Relationship | Reference to the pests known to attack this crop. | Optional |
+| hasAgriSoil | Relationship | Reference to the recommended types of soil suitable for growing this crop. | Optional |
+| hasAgriFertiliser | Relationship | Reference to the recommended types of fertiliser suitable for growing this crop. | Optional |
+| hasAgriPest | Relationship | Reference to the pests known to attack this crop. | Optional |
 | plantingFrom | Property | A list of the recommended planting interval date(s) for this crop. Specified using ISO8601 repeating date intervals: <br/><br/>**interval, description**<br/><br/>Where **interval** is in the form of **start date/end date**<br/><br/>--MM-DD/--MM-DD<br/><br/>Meaning repeat each year from this start date to this end date. | Optional |
 | harvestingInterval | Property | A list of the recommended harvesting interval date(s) for this crop. Specified using ISO8601 repeating date intervals: <br/><br/>**interval, description**<br/><br/>Where **interval** is in the form of **start date/end date**<br/><br/>--MM-DD/--MM-DD<br/><br/>Meaning repeat each year from this start date to this end date. | Optional |
 | wateringFrequency | Property | A description of the recommended watering schedule. A choice from an enumerated list. One of: **daily, weekly, biweekly, monthly, onDemand, other** | Optional |
@@ -28,18 +28,9 @@ The following NGSI-LD context definition applies to the **Agri Crop** entity
 ```JavaScript
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
         "alternateName": "https://schema.org/alternateName",
-        "description": "https://schema.org/description",
-        "agriSoil": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agrisoil",
-        "agriFertiliser": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agrifertiliser",
-        "agriPest": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agripest",
-        "plantingFrom": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/plantingfrom",
-        "harvestingInterval": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/harvestinginterval",
-        "wateringFrequency": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/wateringfrequency"
+        "description": "https://schema.org/description"
     }
 }
 ```
@@ -73,21 +64,21 @@ The following is an example instance of the **Agri Crop** entity
         "type": "Property",
         "value": "Spring wheat"
     },
-    "agriSoil": {
+    "hasAgriSoil": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriSoil:00411b56-bd1b-4551-96e0-a6e7fde9c840",
             "urn:ngsi-ld:AgriSoil:e8a8389a-edf5-4345-8d2c-b98ac1ce8e2a"
         ]
     },
-    "agriFertiliser": {
+    "hasAgriFertiliser": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriFertiliser:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",
             "urn:ngsi-ld:AgriFertiliser:380973c8-4d3b-4723-a899-0c0c5cc63e7e"
         ]
     },
-    "agriPest": {
+    "hasAgriPest": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriPest:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",

--- a/definitions/Agri-Greenhouse.md
+++ b/definitions/Agri-Greenhouse.md
@@ -10,16 +10,16 @@ This entity contains a harmonised description of the conditions recorded within 
 | source | Property | Specifies the URL to the source of this data (either organisation or where relevant more specific source) | Recommended |
 | dataProvider | Property | Specifies the URL to information about the provider of this information | Recommended |
 | entityVersion | Property | The entity specification version as a number. A version number of 2.0 or later denotes the entity is represented using NGSI-LD | Recommended |
-| agriParcelParent | Relationship | Reference to the AgriParcel entity to which this entity relates. | Mandatory |
-| agriParcelChildren | Relationship | Related sub AgriParcel records to which this entity relates. | Optional |
-| weatherObserved | Relationship | Reference to the weather observation record current for this entity. | Recommended |
-| waterQualityObserved | Relationship | Reference to one or more water quality observation records current for this entity. | Recommended |
+| hasAgriParcelParent | Relationship | Reference to the AgriParcel entity to which this entity relates. | Mandatory |
+| hasAgriParcelChildren | Relationship | Related sub AgriParcel records to which this entity relates. | Optional |
+| hasWeatherObserved | Relationship | Reference to the weather observation record current for this entity. | Recommended |
+| hasWaterQualityObserved | Relationship | Reference to one or more water quality observation records current for this entity. | Recommended |
 | relativeHumidity | Property | The inside relative humidity expressed as a number between 0 and 1 representing the range 0% to 100 (%).<br/><br/>0 ≤ relativeHumidity ≤ 1 | Recommended |
 | leafTemperature | Property | The average greenhouse air temperature nominally in degrees centigrade. | Recommended |
 | co2 | Property | The measured interior C02 concentration nominally in mg/L. | Optional |
 | dailyLight | Property | Daily Accumulated light measured in kW per square metre | Optional |
 | drainFlow | Property | The observed drain flow rate in litres per second | Optional |
-| devices | Relationship | Reference to the IoT devices associated with this greenhouse i.e. sensors, controls. | Recommended |
+| hasDevice | Relationship | Reference to the IoT devices associated with this greenhouse i.e. sensors, controls. | Recommended |
 
 ## NGSI-LD Context Definition
 The following NGSI-LD context definition applies to the **Agri Greenhouse** entity
@@ -28,21 +28,7 @@ The following NGSI-LD context definition applies to the **Agri Greenhouse** enti
 
 ```JavaScript
 {
-    "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "agriParcelParent": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelparent",
-        "agriParcelChildren": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelchildren",
-        "weatherObserved": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/weatherobserved",
-        "waterQualityObserved": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/waterqualityobserved",
-        "relativeHumidity": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/relativehumidity",
-        "leafTemperature": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/leaftemperature",
-        "co2": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/co2",
-        "dailyLight": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dailylight",
-        "drainFlow": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/drainflow",
-        "devices": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/devices"
-    }
+    "@context": {}
 }
 ```
 ## Example of Agri Greenhouse Entity
@@ -63,22 +49,22 @@ The following is an example instance of the **Agri Greenhouse** entity
     "source": "https://source.example.com",
     "dataProvider": "https://provider.example.com",
     "entityVersion": 2.0,
-    "agriParcelParent": {
+    "hasAgriParcelParent": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:c8b475e5-84a8-4346-ad79-cde1d2a4028b"
     },
-    "agriParcelChildren": {
+    "hasAgriParcelChildren": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriParcel:8c3a525d-b42e-4048-bcdd-a119d8ddb0a5",
             "urn:ngsi-ld:AgriParcel:178d74c1-e6fe-4042-b955-2c164fc90b83"
         ]
     },
-    "weatherObserved": {
+    "hasWeatherObserved": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:WeatherObserved:c720cec5-ac6f-40b7-8e89-becb75702d0d"
     },
-    "waterQualityObserved": {
+    "hasWaterQualityObserved": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:WaterQualityObserved:49f86e0b-bb90-4751-a1c3-d5a891920807",
@@ -120,7 +106,7 @@ The following is an example instance of the **Agri Greenhouse** entity
         "unitCode": "G51",
         "observedAt": "2016-08-22T19:20Z"
     },
-    "devices": {
+    "hasDevice": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",

--- a/definitions/Agri-Parcel-Operation.md
+++ b/definitions/Agri-Parcel-Operation.md
@@ -10,18 +10,18 @@ This entity contains a harmonised description of a generic operations performed 
 | source | Property | Specifies the URL to the source of this data (either organisation or where relevant more specific source) | Recommended |
 | dataProvider | Property | Specifies the URL to information about the provider of this information | Recommended |
 | entityVersion | Property | The entity specification version as a number. A version number of 2.0 or later denotes the entity is represented using NGSI-LD | Recommended |
-| agriParcel | Relationship | Reference to the AgriParcel to which this entity relates. | Mandatory |
+| hasAgriParcel | Relationship | Reference to the AgriParcel to which this entity relates. | Mandatory |
 | operationType | Property | A choice from an enumerated list describing the operation performed on the parcel. One of: **fertiliser, inspection, pesticide, water, other.** | Recommended |
 | description | Property | A description of the operation. | Recommended |
 | result | Property | A description of the results of the operation. One of: **ok, aborted, failed.** | Recommended |
 | plannedStartAt | DateTime | The planned start date/timestamp for the operation. <br/><br/>Note that this is advisory and the actual time the operation starts may be before or after the planned start. | Mandatory |
 | plannedEndAt | DateTime | The planned end date/timestamp for the operation. <br/><br/>Note that this is advisory and the actual time the operation finishes may be before or after the planned end. | Mandatory |
 | status | Property | A choice from an enumerated list describing the status. One of: **planned, ongoing, finished, scheduled, cancelled.** | Recommended |
-| operator | Relationship | Reference to the operator conducting the operation | Recommended |
+| hasOperator | Relationship | Reference to the operator conducting the operation | Recommended |
 | startedAt | DateTime | Timestamp when the operation actually started to be performed. | Recommended |
 | endedAt | DateTime | Timestamp when the operation actually finished. | Recommended |
 | reportedAt | DateTime | Timestamp when the event/ fault was reported. | Recommended |
-| agriProduct | Relationship | Reference to the AgriProduct used/ applied. | Optional |
+| hasAgriProductType | Relationship | Reference to the AgriProductType used/ applied. | Optional |
 | quantity | Property | The total quantity of water or product used/ applied. It is recommended this is measured in litres for liquids or kilogrammes for solids. | Optional |
 | waterSource | Property | If water was applied/ use this specifies the source. One of: **borehole, rainfall, river, rainwater capture, water dam, commercial supply.** | Recommended |
 | <em>startDate</em> | <em>DateTime</em> | <em>The planned start date/timestamp for the operation. <br/><br/>Note that this is advisory and the actual time the operation starts may be before or after the planned start.<br/><br/>Note this field was defined for use with NGSIv2 and is now deprecated. For new entities and applications replace with **plannedStartAt**</em> | <em>Deprecated</em> |
@@ -37,13 +37,7 @@ The following NGSI-LD context definition applies to the **Agri Parcel Operation*
 ```JavaScript
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "agriParcel": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcel",
-        "operationType": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/operationtype",
         "description": "https://schema.org/description",
-        "result": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/result",
         "plannedStartAt": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/plannedstartat"
@@ -52,8 +46,6 @@ The following NGSI-LD context definition applies to the **Agri Parcel Operation*
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/plannedendat"
         },
-        "status": "http://uri.etsi.org/ngsi-ld/status",
-        "operator": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/operator",
         "startedAt": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/startedat"
@@ -66,9 +58,6 @@ The following NGSI-LD context definition applies to the **Agri Parcel Operation*
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/reportedat"
         },
-        "agriProduct": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproduct",
-        "quantity": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/quantity",
-        "waterSource": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/watersource",
         "startDate": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/startdate"
@@ -106,7 +95,7 @@ The following is an example instance of the **Agri Parcel Operation** entity
     "source": "https://source.example.com",
     "dataProvider": "https://provider.example.com",
     "entityVersion": 2.0,
-    "agriParcel": {
+    "hasAgriParcel": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:318366a9-7643-4d8e-9a11-c76a8c29d8eb"
     },
@@ -134,7 +123,7 @@ The following is an example instance of the **Agri Parcel Operation** entity
         "type": "Property",
         "value": "finished"
     },
-    "operator": {
+    "hasOperator": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:Person:fce9dcbc-4479-11e8-9de1-cb228de7a15c"
     },
@@ -150,9 +139,9 @@ The following is an example instance of the **Agri Parcel Operation** entity
         "type": "Property",
         "value": "2016-08-28T10:18:16Z"
     },
-    "agriProduct": {
+    "hasAgriProductType": {
         "type": "Relationship",
-        "object": "urn:ngsi-ld:AgriProduct:a8f616b8-13fb-473a-8e61-b7a80c6c93ec"
+        "object": "urn:ngsi-ld:AgriProductType:a8f616b8-13fb-473a-8e61-b7a80c6c93ec"
     },
     "quantity": {
         "type": "Property",

--- a/definitions/Agri-Parcel-Record.md
+++ b/definitions/Agri-Parcel-Record.md
@@ -10,7 +10,7 @@ This entity contains a harmonised description of the conditions recorded on a ge
 | source | Property | Specifies the URL to the source of this data (either organisation or where relevant more specific source) | Recommended |
 | dataProvider | Property | Specifies the URL to information about the provider of this information | Recommended |
 | entityVersion | Property | The entity specification version as a number. A version number of 2.0 or later denotes the entity is represented using NGSI-LD | Recommended |
-| agriParcel | Relationship | Reference to the AgriParcel to which this entity relates. | Mandatory |
+| hasAgriParcel | Relationship | Reference to the AgriParcel to which this entity relates. | Mandatory |
 | location | GeoProperty | The geo:json encoded polygon / multi-polygon describing the parcel which this record relates to. | Mandatory |
 | soilTemperature | Property | The observed soil temperature nominally in degrees centigrade. | Optional |
 | soilMoistureVwc | Property | Measured as Volumetric Water Content, VWC as a percentage.<br/><br/>0 ≤soilMoistureVwc ≤ 1 | Optional |
@@ -20,7 +20,7 @@ This entity contains a harmonised description of the conditions recorded on a ge
 | relativeHumidity | Property | Relative Humidity a number between 0 and 1 representing the range of 0% to 100%.<br/><br/>0 ≤ relativeHumidity ≤ 1  | Optional |
 | atmosphericPressure | Property | Atmospheric Pressure nominally in units of hecto Pascals. | Recommended |
 | description | Property | A description of this record | Recommended |
-| devices | Relationship | Reference to the IoT devices associated with this greenhouse i.e. sensors, controls. | Recommended |
+| hasDevice | Relationship | Reference to the IoT devices associated with this greenhouse i.e. sensors, controls. | Recommended |
 | observedAt | DateTime | Indicates the date/time the record was observed/ last observed. | Recommended |
 
 ## NGSI-LD Context Definition
@@ -31,20 +31,11 @@ The following NGSI-LD context definition applies to the **Agri Parcel Record** e
 ```JavaScript
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "agriParcel": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcel",
-        "location": "http://uri.etsi.org/ngsi-ld/location",
-        "soilTemperature": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/soiltemperature",
-        "soilMoistureVwc": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/soilmoisturevwc",
-        "soilMoistureEc": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/soilmoistureec",
-        "airTemperature": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/airtemperature",
-        "solarRadiation": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/solarradiation",
-        "relativeHumidity": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/relativehumidity",
-        "atmosphericPressure": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/atmosphericpressure",
         "description": "https://schema.org/description",
-        "devices": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/devices"
+        "observedAt": {
+            "@type": "DateTime",
+            "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/observedat"
+        }
     }
 }
 ```
@@ -66,7 +57,7 @@ The following is an example instance of the **Agri Parcel Record** entity
     "source": "https://source.example.com",
     "dataProvider": "https://provider.example.com",
     "entityVersion": 2.0,
-    "agriParcel": {
+    "hasAgriParcel": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:d3676010-d815-468c-9e01-25739c5a25ed"
     },
@@ -144,7 +135,7 @@ The following is an example instance of the **Agri Parcel Record** entity
         "type": "Property",
         "value": "Monthly fertiliser application"
     },
-    "devices": {
+    "hasDevice": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",

--- a/definitions/Agri-Parcel.md
+++ b/definitions/Agri-Parcel.md
@@ -14,13 +14,13 @@ This entity contains a harmonised description of a generic parcel of land. This 
 | area | Property | The area of the parcel nominally in square meters. | Mandatory |
 | description | Property | Home Farm - North West field. | Recommended |
 | category | Property | The category of the parcel of land e.g.: **arable, grassland, vineyard, orchard, mixed crop, lowland, upland, set-aside, forestry, wetland.** | Recommended |
-| agriParcelParent | Relationship | An optional reference to a higher level (parent) AgriParcel entity to which this entity relates. | Optional |
-| agriParcelChildren | Relationship | An optional reference to lower level (child) AgriParcel records to which this entity relates. | Optional |
-| agriCrop | Relationship | Reference to the crop associated with this parcel | Mandatory |
+| hasAgriParcelParent | Relationship | An optional reference to a higher level (parent) AgriParcel entity to which this entity relates. | Optional |
+| hasAgriParcelChildren | Relationship | An optional reference to lower level (child) AgriParcel records to which this entity relates. | Optional |
+| hasAgriCrop | Relationship | Reference to the crop associated with this parcel | Mandatory |
 | cropStatus | Property | A choice from an enumerated list describing the crop planting status One of: **seeded, justBorn, growing, maturing, readyForHarvesting.** | Recommended |
 | lastPlantedAt | DateTime | Indicates the date when the crop was last planted. | Recommended |
-| agriSoil | Relationship | Reference to the soil associated with this parcel of land. | Optional |
-| devices | Relationship | Reference to the IoT devices associated with this parcel i.e. sensors, controls. | Recommended |
+| hasAgriSoil | Relationship | Reference to the soil associated with this parcel of land. | Optional |
+| hasDevice | Relationship | Reference to the IoT devices associated with this parcel i.e. sensors, controls. | Recommended |
 | <em>dateLastPlanted</em> | <em>DateTime</em> | <em>Indicates the date when the crop was last planted.<br/><br/>Note this field was defined for use with NGSIv2 and is now deprecated. For new entities and applications replace with **lastPlantedAt**</em> | <em>Deprecated</em> |
 
 ## NGSI-LD Context Definition
@@ -31,23 +31,11 @@ The following NGSI-LD context definition applies to the **Agri Parcel** entity
 ```JavaScript
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "location": "http://uri.etsi.org/ngsi-ld/location",
-        "area": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/area",
         "description": "https://schema.org/description",
-        "category": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/category",
-        "agriParcelParent": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelparent",
-        "agriParcelChildren": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelchildren",
-        "agriCrop": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agricrop",
-        "cropStatus": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/cropstatus",
         "lastPlantedAt": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/lastplantedat"
         },
-        "agriSoil": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agrisoil",
-        "devices": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/devices",
         "dateLastPlanted": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/datelastplanted"
@@ -114,18 +102,18 @@ The following is an example instance of the **Agri Parcel** entity
         "type": "Property",
         "value": "arable"
     },
-    "agriParcelParent": {
+    "hasAgriParcelParent": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:1ea0f120-4474-11e8-9919-672036642081"
     },
-    "agriParcelChildren": {
+    "hasAgriParcelChildren": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriParcel:26ba4be0-4474-11e8-8ec1-ab9e0ea93835",
             "urn:ngsi-ld:AgriParcel:2d5b8874-4474-11e8-8d6b-dbe14425b5e4"
         ]
     },
-    "agriCrop": {
+    "hasAgriCrop": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriCrop:36021150-4474-11e8-a721-af07c5fae7c8"
     },
@@ -137,11 +125,11 @@ The following is an example instance of the **Agri Parcel** entity
         "type": "Property",
         "value": "2016-08-23T10:18:16Z"
     },
-    "agriSoil": {
+    "hasAgriSoil": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriSoil:429d1338-4474-11e8-b90a-d3e34ceb73df"
     },
-    "devices": {
+    "hasDevice": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",

--- a/definitions/Agri-Pest.md
+++ b/definitions/Agri-Pest.md
@@ -13,7 +13,7 @@ This entity contains a harmonised description of an agricultural pest. This enti
 | name | Property | The name of this agricultural pest. | Mandatory |
 | alternateName | Property | Alternative name of this agricultural pest. | Optional |
 | description | Property | A description of this agricultural pest. | Recommended |
-| agriProduct | Relationship | Reference to the recommended types of product that can be used to treat this pest. | Optional |
+| hasAgriProductType | Relationship | Reference to the recommended types of product that can be used to treat this pest. | Optional |
 
 ## NGSI-LD Context Definition
 The following NGSI-LD context definition applies to the **Agri Pest** entity
@@ -23,13 +23,9 @@ The following NGSI-LD context definition applies to the **Agri Pest** entity
 ```JavaScript
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
         "alternateName": "https://schema.org/alternateName",
-        "description": "https://schema.org/description",
-        "agriProduct": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproduct"
+        "description": "https://schema.org/description"
     }
 }
 ```
@@ -63,12 +59,12 @@ The following is an example instance of the **Agri Pest** entity
         "type": "Property",
         "value": "Common European grasshopper"
     },
-    "agriProduct": {
+    "hasAgriProductType": {
         "type": "Relationship",
         "object": [
-            "urn:ngsi-ld:AgriProduct:06afffde-4488-11e8-861a-cfcf50aaa9cc",
-            "urn:ngsi-ld:AgriProduct:0c094486-4488-11e8-a15f-afa816790c64",
-            "urn:ngsi-ld:AgriProduct:14bf9f26-4488-11e8-9e3d-bfb78de66dd3"
+            "urn:ngsi-ld:AgriProductType:06afffde-4488-11e8-861a-cfcf50aaa9cc",
+            "urn:ngsi-ld:AgriProductType:0c094486-4488-11e8-a15f-afa816790c64",
+            "urn:ngsi-ld:AgriProductTypes:14bf9f26-4488-11e8-9e3d-bfb78de66dd3"
         ]
     }
 }

--- a/definitions/Agri-Product-Type.md
+++ b/definitions/Agri-Product-Type.md
@@ -13,8 +13,8 @@ This entity contains a harmonised description of a generic agricultural product 
 | name | Property | The name of this product type. | Mandatory |
 | description | Property | A description of this product type. | Mandatory |
 | root | Property | A logical indicator that this product is the root of an AgriProductType hierarchy. Logical true indicates it is the root. | Mandatory |
-| agriProductParent | Relationship | Reference to the parent product type i.e. immediately above the entity in the hierarchy. | Optional |
-| agriProductChildren | Relationship | Reference to child product types i.e. immediately below this entity in the hierarchy. | Optional |
+| hasAgriProductTypeParent | Relationship | Reference to the parent product type i.e. immediately above the entity in the hierarchy. | Optional |
+| hasAgriProductTypeChildren | Relationship | Reference to child product types i.e. immediately below this entity in the hierarchy. | Optional |
 
 ## NGSI-LD Context Definition
 The following NGSI-LD context definition applies to the **Agri Product Type** entity
@@ -24,14 +24,8 @@ The following NGSI-LD context definition applies to the **Agri Product Type** en
 ```JavaScript
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
-        "description": "https://schema.org/description",
-        "root": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/root",
-        "agriProductParent": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproductparent",
-        "agriProductChildren": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproductchildren"
+        "description": "https://schema.org/description"
     }
 }
 ```
@@ -65,11 +59,11 @@ The following is an example instance of the **Agri Product Type** entity
         "type": "Property",
         "value": true
     },
-    "agriProductParent": {
+    "hasAgriProductTypeParent": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriProductType:b99c940d-7156-4280-9a2b-4a9e533cd20e"
     },
-    "agriProductChildren": {
+    "hasAgriProductTypeChildren": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriProductType:836258d0-448b-11e8-84ec-ef61d9425fe8",

--- a/definitions/Agri-Soil.md
+++ b/definitions/Agri-Soil.md
@@ -13,7 +13,7 @@ This entity contains a harmonised description of soil. This entity is primarily 
 | name | Property | The name of this soil type. | Mandatory |
 | alternateName | Property | Alternative name of this soil type. | Optional |
 | description | Property | A description of this soil. | Recommended |
-| agriProduct | Relationship | Reference to the recommended types of product (such as fertiliser) that can be used to condition this soil type. | Optional |
+| hasAgriProductType | Relationship | Reference to the recommended types of product (such as fertiliser) that can be used to condition this soil type. | Optional |
 
 ## NGSI-LD Context Definition
 The following NGSI-LD context definition applies to the **Agri Soil** entity
@@ -23,13 +23,9 @@ The following NGSI-LD context definition applies to the **Agri Soil** entity
 ```JavaScript
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
         "alternateName": "https://schema.org/alternateName",
-        "description": "https://schema.org/description",
-        "agriProduct": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproduct"
+        "description": "https://schema.org/description"
     }
 }
 ```
@@ -63,11 +59,11 @@ The following is an example instance of the **Agri Soil** entity
         "type": "Property",
         "value": "Fine grained, poor draining soil. Particle size less than 0.002mm"
     },
-    "agriProduct": {
+    "hasAgriProductType": {
         "type": "Relationship",
         "object": [
-            "urn:ngsi-ld:AgriProduct:ea54eedf-d5a7-4e44-bddd-50e9935237c0",
-            "urn:ngsi-ld:AgriProduct:275b4c08-5e52-4bb7-8523-74ce5d0007de"
+            "urn:ngsi-ld:AgriProductType:ea54eedf-d5a7-4e44-bddd-50e9935237c0",
+            "urn:ngsi-ld:AgriProductType:275b4c08-5e52-4bb7-8523-74ce5d0007de"
         ]
     }
 }

--- a/examples/Agri-Crop-context.jsonld
+++ b/examples/Agri-Crop-context.jsonld
@@ -1,16 +1,7 @@
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
         "alternateName": "https://schema.org/alternateName",
-        "description": "https://schema.org/description",
-        "agriSoil": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agrisoil",
-        "agriFertiliser": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agrifertiliser",
-        "agriPest": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agripest",
-        "plantingFrom": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/plantingfrom",
-        "harvestingInterval": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/harvestinginterval",
-        "wateringFrequency": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/wateringfrequency"
+        "description": "https://schema.org/description"
     }
 }

--- a/examples/Agri-Crop.jsonld
+++ b/examples/Agri-Crop.jsonld
@@ -22,21 +22,21 @@
         "type": "Property",
         "value": "Spring wheat"
     },
-    "agriSoil": {
+    "hasAgriSoil": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriSoil:00411b56-bd1b-4551-96e0-a6e7fde9c840",
             "urn:ngsi-ld:AgriSoil:e8a8389a-edf5-4345-8d2c-b98ac1ce8e2a"
         ]
     },
-    "agriFertiliser": {
+    "hasAgriFertiliser": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriFertiliser:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",
             "urn:ngsi-ld:AgriFertiliser:380973c8-4d3b-4723-a899-0c0c5cc63e7e"
         ]
     },
-    "agriPest": {
+    "hasAgriPest": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriPest:1b0d6cf7-320c-4a2b-b2f1-4575ea850c73",

--- a/examples/Agri-Greenhouse-context.jsonld
+++ b/examples/Agri-Greenhouse-context.jsonld
@@ -1,17 +1,3 @@
 {
-    "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "agriParcelParent": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelparent",
-        "agriParcelChildren": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelchildren",
-        "weatherObserved": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/weatherobserved",
-        "waterQualityObserved": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/waterqualityobserved",
-        "relativeHumidity": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/relativehumidity",
-        "leafTemperature": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/leaftemperature",
-        "co2": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/co2",
-        "dailyLight": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dailylight",
-        "drainFlow": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/drainflow",
-        "devices": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/devices"
-    }
+    "@context": {}
 }

--- a/examples/Agri-Greenhouse.jsonld
+++ b/examples/Agri-Greenhouse.jsonld
@@ -10,22 +10,22 @@
     "source": "https://source.example.com",
     "dataProvider": "https://provider.example.com",
     "entityVersion": 2.0,
-    "agriParcelParent": {
+    "hasAgriParcelParent": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:c8b475e5-84a8-4346-ad79-cde1d2a4028b"
     },
-    "agriParcelChildren": {
+    "hasAgriParcelChildren": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriParcel:8c3a525d-b42e-4048-bcdd-a119d8ddb0a5",
             "urn:ngsi-ld:AgriParcel:178d74c1-e6fe-4042-b955-2c164fc90b83"
         ]
     },
-    "weatherObserved": {
+    "hasWeatherObserved": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:WeatherObserved:c720cec5-ac6f-40b7-8e89-becb75702d0d"
     },
-    "waterQualityObserved": {
+    "hasWaterQualityObserved": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:WaterQualityObserved:49f86e0b-bb90-4751-a1c3-d5a891920807",
@@ -67,7 +67,7 @@
         "unitCode": "G51",
         "observedAt": "2016-08-22T19:20Z"
     },
-    "devices": {
+    "hasDevice": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",

--- a/examples/Agri-Parcel-Operation-context.jsonld
+++ b/examples/Agri-Parcel-Operation-context.jsonld
@@ -1,12 +1,6 @@
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "agriParcel": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcel",
-        "operationType": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/operationtype",
         "description": "https://schema.org/description",
-        "result": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/result",
         "plannedStartAt": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/plannedstartat"
@@ -15,8 +9,6 @@
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/plannedendat"
         },
-        "status": "http://uri.etsi.org/ngsi-ld/status",
-        "operator": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/operator",
         "startedAt": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/startedat"
@@ -29,9 +21,6 @@
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/reportedat"
         },
-        "agriProduct": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproduct",
-        "quantity": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/quantity",
-        "waterSource": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/watersource",
         "startDate": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/startdate"

--- a/examples/Agri-Parcel-Operation.jsonld
+++ b/examples/Agri-Parcel-Operation.jsonld
@@ -10,7 +10,7 @@
     "source": "https://source.example.com",
     "dataProvider": "https://provider.example.com",
     "entityVersion": 2.0,
-    "agriParcel": {
+    "hasAgriParcel": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:318366a9-7643-4d8e-9a11-c76a8c29d8eb"
     },
@@ -38,7 +38,7 @@
         "type": "Property",
         "value": "finished"
     },
-    "operator": {
+    "hasOperator": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:Person:fce9dcbc-4479-11e8-9de1-cb228de7a15c"
     },
@@ -54,9 +54,9 @@
         "type": "Property",
         "value": "2016-08-28T10:18:16Z"
     },
-    "agriProduct": {
+    "hasAgriProductType": {
         "type": "Relationship",
-        "object": "urn:ngsi-ld:AgriProduct:a8f616b8-13fb-473a-8e61-b7a80c6c93ec"
+        "object": "urn:ngsi-ld:AgriProductType:a8f616b8-13fb-473a-8e61-b7a80c6c93ec"
     },
     "quantity": {
         "type": "Property",

--- a/examples/Agri-Parcel-Record-context.jsonld
+++ b/examples/Agri-Parcel-Record-context.jsonld
@@ -1,18 +1,9 @@
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "agriParcel": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcel",
-        "location": "http://uri.etsi.org/ngsi-ld/location",
-        "soilTemperature": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/soiltemperature",
-        "soilMoistureVwc": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/soilmoisturevwc",
-        "soilMoistureEc": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/soilmoistureec",
-        "airTemperature": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/airtemperature",
-        "solarRadiation": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/solarradiation",
-        "relativeHumidity": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/relativehumidity",
-        "atmosphericPressure": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/atmosphericpressure",
         "description": "https://schema.org/description",
-        "devices": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/devices"
+        "observedAt": {
+            "@type": "DateTime",
+            "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/observedat"
+        }
     }
 }

--- a/examples/Agri-Parcel-Record.jsonld
+++ b/examples/Agri-Parcel-Record.jsonld
@@ -10,7 +10,7 @@
     "source": "https://source.example.com",
     "dataProvider": "https://provider.example.com",
     "entityVersion": 2.0,
-    "agriParcel": {
+    "hasAgriParcel": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:d3676010-d815-468c-9e01-25739c5a25ed"
     },
@@ -88,7 +88,7 @@
         "type": "Property",
         "value": "Monthly fertiliser application"
     },
-    "devices": {
+    "hasDevice": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",

--- a/examples/Agri-Parcel-context.jsonld
+++ b/examples/Agri-Parcel-context.jsonld
@@ -1,22 +1,10 @@
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
-        "location": "http://uri.etsi.org/ngsi-ld/location",
-        "area": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/area",
         "description": "https://schema.org/description",
-        "category": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/category",
-        "agriParcelParent": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelparent",
-        "agriParcelChildren": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriparcelchildren",
-        "agriCrop": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agricrop",
-        "cropStatus": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/cropstatus",
         "lastPlantedAt": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/lastplantedat"
         },
-        "agriSoil": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agrisoil",
-        "devices": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/devices",
         "dateLastPlanted": {
             "@type": "DateTime",
             "@id": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/datelastplanted"

--- a/examples/Agri-Parcel.jsonld
+++ b/examples/Agri-Parcel.jsonld
@@ -51,18 +51,18 @@
         "type": "Property",
         "value": "arable"
     },
-    "agriParcelParent": {
+    "hasAgriParcelParent": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriParcel:1ea0f120-4474-11e8-9919-672036642081"
     },
-    "agriParcelChildren": {
+    "hasAgriParcelChildren": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriParcel:26ba4be0-4474-11e8-8ec1-ab9e0ea93835",
             "urn:ngsi-ld:AgriParcel:2d5b8874-4474-11e8-8d6b-dbe14425b5e4"
         ]
     },
-    "agriCrop": {
+    "hasAgriCrop": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriCrop:36021150-4474-11e8-a721-af07c5fae7c8"
     },
@@ -74,11 +74,11 @@
         "type": "Property",
         "value": "2016-08-23T10:18:16Z"
     },
-    "agriSoil": {
+    "hasAgriSoil": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriSoil:429d1338-4474-11e8-b90a-d3e34ceb73df"
     },
-    "devices": {
+    "hasDevice": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:Device:4a40aeba-4474-11e8-86bf-03d82e958ce6",

--- a/examples/Agri-Pest-context.jsonld
+++ b/examples/Agri-Pest-context.jsonld
@@ -1,11 +1,7 @@
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
         "alternateName": "https://schema.org/alternateName",
-        "description": "https://schema.org/description",
-        "agriProduct": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproduct"
+        "description": "https://schema.org/description"
     }
 }

--- a/examples/Agri-Pest.jsonld
+++ b/examples/Agri-Pest.jsonld
@@ -22,12 +22,12 @@
         "type": "Property",
         "value": "Common European grasshopper"
     },
-    "agriProduct": {
+    "hasAgriProductType": {
         "type": "Relationship",
         "object": [
-            "urn:ngsi-ld:AgriProduct:06afffde-4488-11e8-861a-cfcf50aaa9cc",
-            "urn:ngsi-ld:AgriProduct:0c094486-4488-11e8-a15f-afa816790c64",
-            "urn:ngsi-ld:AgriProduct:14bf9f26-4488-11e8-9e3d-bfb78de66dd3"
+            "urn:ngsi-ld:AgriProductType:06afffde-4488-11e8-861a-cfcf50aaa9cc",
+            "urn:ngsi-ld:AgriProductType:0c094486-4488-11e8-a15f-afa816790c64",
+            "urn:ngsi-ld:AgriProductTypes:14bf9f26-4488-11e8-9e3d-bfb78de66dd3"
         ]
     }
 }

--- a/examples/Agri-Product-Type-context.jsonld
+++ b/examples/Agri-Product-Type-context.jsonld
@@ -1,12 +1,6 @@
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
-        "description": "https://schema.org/description",
-        "root": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/root",
-        "agriProductParent": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproductparent",
-        "agriProductChildren": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproductchildren"
+        "description": "https://schema.org/description"
     }
 }

--- a/examples/Agri-Product-Type.jsonld
+++ b/examples/Agri-Product-Type.jsonld
@@ -22,11 +22,11 @@
         "type": "Property",
         "value": true
     },
-    "agriProductParent": {
+    "hasAgriProductTypeParent": {
         "type": "Relationship",
         "object": "urn:ngsi-ld:AgriProductType:b99c940d-7156-4280-9a2b-4a9e533cd20e"
     },
-    "agriProductChildren": {
+    "hasAgriProductTypeChildren": {
         "type": "Relationship",
         "object": [
             "urn:ngsi-ld:AgriProductType:836258d0-448b-11e8-84ec-ef61d9425fe8",

--- a/examples/Agri-Soil-context.jsonld
+++ b/examples/Agri-Soil-context.jsonld
@@ -1,11 +1,7 @@
 {
     "@context": {
-        "source": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/source",
-        "dataProvider": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/dataprovider",
-        "entityVersion": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/entityversion",
         "name": "https://schema.org/name",
         "alternateName": "https://schema.org/alternateName",
-        "description": "https://schema.org/description",
-        "agriProduct": "https://www.gsma.com/iot/iot-big-data/ngsi-ld/agriproduct"
+        "description": "https://schema.org/description"
     }
 }

--- a/examples/Agri-Soil.jsonld
+++ b/examples/Agri-Soil.jsonld
@@ -22,11 +22,11 @@
         "type": "Property",
         "value": "Fine grained, poor draining soil. Particle size less than 0.002mm"
     },
-    "agriProduct": {
+    "hasAgriProductType": {
         "type": "Relationship",
         "object": [
-            "urn:ngsi-ld:AgriProduct:ea54eedf-d5a7-4e44-bddd-50e9935237c0",
-            "urn:ngsi-ld:AgriProduct:275b4c08-5e52-4bb7-8523-74ce5d0007de"
+            "urn:ngsi-ld:AgriProductType:ea54eedf-d5a7-4e44-bddd-50e9935237c0",
+            "urn:ngsi-ld:AgriProductType:275b4c08-5e52-4bb7-8523-74ce5d0007de"
         ]
     }
 }


### PR DESCRIPTION
This PR includes an update of AgriFood datamodels to use verb-based relationships (e.g hasDevice rather than devices) according to last changes done in FIWARE data models definitions. 